### PR TITLE
fix: 'hot' does not exist on type 'NodeModuls'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
 
-    "noEmit": true
+    "noEmit": true,
+    "types": ["webpack-env"]
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
fix: 'hot' does not exist on type 'NodeModuls'